### PR TITLE
feat(k8s): coscheduler plugin

### DIFF
--- a/examples/tutorials/fashion_mnist_tf_keras/distributed.yaml
+++ b/examples/tutorials/fashion_mnist_tf_keras/distributed.yaml
@@ -3,7 +3,7 @@ hyperparameters:
   global_batch_size: 256
   dense1: 128
 resources:
-  slots_per_trial: 480
+  slots_per_trial: 8
 records_per_epoch: 60000
 searcher:
   name: single

--- a/examples/tutorials/fashion_mnist_tf_keras/distributed.yaml
+++ b/examples/tutorials/fashion_mnist_tf_keras/distributed.yaml
@@ -3,7 +3,7 @@ hyperparameters:
   global_batch_size: 256
   dense1: 128
 resources:
-  slots_per_trial: 768
+  slots_per_trial: 480
 records_per_epoch: 60000
 searcher:
   name: single

--- a/examples/tutorials/fashion_mnist_tf_keras/distributed.yaml
+++ b/examples/tutorials/fashion_mnist_tf_keras/distributed.yaml
@@ -3,7 +3,7 @@ hyperparameters:
   global_batch_size: 256
   dense1: 128
 resources:
-  slots_per_trial: 8
+  slots_per_trial: 768
 records_per_epoch: 60000
 searcher:
   name: single

--- a/helm/charts/determined/Chart.yaml
+++ b/helm/charts/determined/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: determined
 description: An open source deep learning training platform with support for distributed training and hyperparameter search.
-version: "0.18.52"
+version: "0.18.53"
 icon: https://github.com/determined-ai/determined/blob/master/determined-logo.png?raw=true
 home: https://www.determined.ai/
 annotations:

--- a/helm/charts/determined/Chart.yaml
+++ b/helm/charts/determined/Chart.yaml
@@ -11,4 +11,4 @@ annotations:
 # a non-release version (e.g., X.Y.Z.dev0) you will have to specify an
 # existing official release version (e.g., X.Y.Z) or specify a commit has
 # that has been publicly published (all commits from master).
-appVersion: "0.19.5"
+appVersion: "0.19.8"

--- a/helm/charts/determined/Chart.yaml
+++ b/helm/charts/determined/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: determined
 description: An open source deep learning training platform with support for distributed training and hyperparameter search.
-version: "0.18.49"
+version: "0.18.51"
 icon: https://github.com/determined-ai/determined/blob/master/determined-logo.png?raw=true
 home: https://www.determined.ai/
 annotations:

--- a/helm/charts/determined/Chart.yaml
+++ b/helm/charts/determined/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: determined
 description: An open source deep learning training platform with support for distributed training and hyperparameter search.
-version: "0.18.51"
+version: "0.18.52"
 icon: https://github.com/determined-ai/determined/blob/master/determined-logo.png?raw=true
 home: https://www.determined.ai/
 annotations:

--- a/helm/charts/determined/README.md
+++ b/helm/charts/determined/README.md
@@ -27,6 +27,7 @@ The Determined application comes pre-configured with most intallations values to
 | vCPU Request | Default number of vCPUs for experiments, can be overriden in experiment configuration. (default: 8) |
 | Memory Request | Default memory allocation for experiemnts, can be overriden in experiment configuration. (default: 32Gi) |
 | GPU Type | Default GPU type for experiments and notebooks, can be overriden in experiment configuration. (default: RTX_A5000) |
+| K8s Scheduler | Default Scheduler type for experiments and notebooks, can be overriden in experiment configuration. (default: default-scheduler) |
 | Mounts | Optional default Persistent Volume mounts for experiments and notebooks, can be overriden in experiment configuration. |
 | Bucket Name (S3) | CoreWeave Object Storage Bucket Name for checkpoints |
 | Access Key (S3) | Access Key for Object Storage |

--- a/helm/charts/determined/README.md
+++ b/helm/charts/determined/README.md
@@ -24,7 +24,7 @@ The Determined application comes pre-configured with most intallations values to
 | Helm Chart Config Value  | Description |
 | ------------- | ------------- |
 | Region | Region where you are deploying determined. This should match the region where you intend to execute most of your training workloads.  |
-| K8s Scheduler | Default Scheduler type for experiments and notebooks, can be overriden in experiment configuration. (default: default-scheduler) |
+| Scheduler | Default Scheduler type for experiments and notebooks, can be overriden in experiment configuration. The standard scheduler is good for most use cases, however large distributed training jobs will want to use coscheduler to allow jobs to queue when resources to run all jobs in parallel are not available. (default: default-scheduler) |
 | vCPU Request | Default number of vCPUs for experiments, can be overriden in experiment configuration. (default: 8) |
 | Memory Request | Default memory allocation for experiemnts, can be overriden in experiment configuration. (default: 32Gi) |
 | GPU Type | Default GPU type for experiments and notebooks, can be overriden in experiment configuration. (default: RTX_A5000) |

--- a/helm/charts/determined/README.md
+++ b/helm/charts/determined/README.md
@@ -24,10 +24,10 @@ The Determined application comes pre-configured with most intallations values to
 | Helm Chart Config Value  | Description |
 | ------------- | ------------- |
 | Region | Region where you are deploying determined. This should match the region where you intend to execute most of your training workloads.  |
+| K8s Scheduler | Default Scheduler type for experiments and notebooks, can be overriden in experiment configuration. (default: default-scheduler) |
 | vCPU Request | Default number of vCPUs for experiments, can be overriden in experiment configuration. (default: 8) |
 | Memory Request | Default memory allocation for experiemnts, can be overriden in experiment configuration. (default: 32Gi) |
 | GPU Type | Default GPU type for experiments and notebooks, can be overriden in experiment configuration. (default: RTX_A5000) |
-| K8s Scheduler | Default Scheduler type for experiments and notebooks, can be overriden in experiment configuration. (default: default-scheduler) |
 | Mounts | Optional default Persistent Volume mounts for experiments and notebooks, can be overriden in experiment configuration. |
 | Bucket Name (S3) | CoreWeave Object Storage Bucket Name for checkpoints |
 | Access Key (S3) | Access Key for Object Storage |

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -92,7 +92,6 @@ data:
          gpu: {{ .Values.imageRegistry }}/{{ $gpuImage }}
       cpu_pod_spec: {{ include "determined.cpuPodSpec" . | fromYaml | toJson }}
       gpu_pod_spec: {{ include "determined.gpuPodSpec" . | fromYaml | toJson }}
-
     {{- if .Values.telemetry }}
     telemetry:
       enabled: {{ .Values.telemetry.enabled }}

--- a/helm/charts/determined/values.schema.json
+++ b/helm/charts/determined/values.schema.json
@@ -56,6 +56,15 @@
             ],
             "form": true,
             "title": "GPU Type"
+          },
+          "defaultScheduler": {
+            "type": "string",
+            "enum": [
+              "default-scheduler",
+              "coscheduler"
+            ],
+            "form": true,
+            "title": "K8s Scheduler"
           }
         }
       },

--- a/helm/charts/determined/values.schema.json
+++ b/helm/charts/determined/values.schema.json
@@ -22,7 +22,8 @@
           "coscheduler"
         ],
         "form": true,
-        "title": "Scheduler"
+        "title": "Scheduler",
+        "description": "Default Scheduler type for experiments and notebooks, can be overriden in experiment configuration. The standard scheduler is good for most use cases, however large distributed training jobs will want to use coscheduler to allow jobs to queue when resources to run all jobs in parallel are not available."
       },
       "resources": {
         "type": "object",

--- a/helm/charts/determined/values.schema.json
+++ b/helm/charts/determined/values.schema.json
@@ -15,6 +15,15 @@
           "component": "RegionSelector"
         }
       },
+      "defaultScheduler": {
+        "type": "string",
+        "enum": [
+          "default-scheduler",
+          "coscheduler"
+        ],
+        "form": true,
+        "title": "K8s Scheduler"
+      },
       "resources": {
         "type": "object",
         "title": "Default Resources",
@@ -56,15 +65,6 @@
             ],
             "form": true,
             "title": "GPU Type"
-          },
-          "defaultScheduler": {
-            "type": "string",
-            "enum": [
-              "default-scheduler",
-              "coscheduler"
-            ],
-            "form": true,
-            "title": "K8s Scheduler"
           }
         }
       },

--- a/helm/charts/determined/values.schema.json
+++ b/helm/charts/determined/values.schema.json
@@ -22,7 +22,7 @@
           "coscheduler"
         ],
         "form": true,
-        "title": "K8s Scheduler"
+        "title": "Scheduler"
       },
       "resources": {
         "type": "object",

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -192,7 +192,7 @@ mounts: []
 ## Configure the default Determined scheduler
 ## Currently supports "coscheduler" for gang scheduling and "preemption" for priority based
 ## scheduling with preemption
-# defaultScheduler: preemption
+defaultScheduler: default-scheduler
 
 ## Configure settings about how Determined launches the Fluentbit sidecar.
 # fluent:


### PR DESCRIPTION
This PR adds an option to choose between ```default-scheduler``` and ```coscheduler``` for running experiments on determined.ai via K8s