### PR TITLE
feat(deepspeed): Add an example using hugging face

### DIFF
--- a/examples/deepspeed/huggingface/Dockerfile
+++ b/examples/deepspeed/huggingface/Dockerfile
@@ -1,0 +1,11 @@
+FROM determinedai/model-hub-transformers:0.18.4-dev0 as model_hub
+
+RUN mkdir /wheels && pip wheel -w /wheels model_hub==0.18.4
+
+FROM determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-0.19.4 as runtime
+
+ADD requirements.txt /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt
+
+COPY --from=model_hub /wheels/model_hub-0.18.4-py3-none-any.whl /tmp/model_hub_wheels/model_hub-0.18.4-py3-none-any.whl
+RUN pip install --find-links=/tmp/model_hub_wheel model-hub

--- a/examples/deepspeed/huggingface/README.md
+++ b/examples/deepspeed/huggingface/README.md
@@ -1,0 +1,93 @@
+# Huggingface
+
+A full walkthrough of running this code is available on
+the ["Finetuning HuggingFace LLMs with Determined AI and DeepSpeed" CoreWeave documentation page.](https://docs.coreweave.com/compass/determined-ai/finetuning-huggingface-llms-with-determined-ai-and-deepspeed)
+
+This example builds upon
+the [model hub huggingface examples](https://github.com/coreweave/coreweave_determined/tree/master/model_hub/examples/huggingface)
+by leveraging [DeepSpeed](https://www.deepspeed.ai/) which boosts the performance of distributed training.
+
+To use DeepSpeed with DeterminedAI, you must use
+the [`DeepSpeedTrial`](https://docs.determined.ai/latest/training/apis-howto/deepspeed/deepspeed.html#deepspeed-api).
+
+## Files
+### Source code
+ - **ds_config.json**: Contains the config that is passed to DeepSpeed.
+ - **lm_trial.py**: The `DeepSpeedTrial` definition for language modeling.
+ - **prepare_lm_data.py**: Script that preprocesses huggingface text datasets for the trials
+ - **Dockerfile**: Defines the docker container that will be used in the trials
+
+### Experiment configuration files
+ - **opt125m_single.yml**: Performs a single trial that finetunes the OPT-125m model
+ - **opt125m_search.yml**: Performs a hyperparameter search on the training micro batch size.
+
+## Local Environment Setup
+First create a local environment and install the requirements.
+```
+conda create --name=hf_deepspeed python=3.9
+conda activate hf_deepspeed
+pip install -r requirements.txt
+```
+
+To install the model_hub package, you need to build it from the source code (which is in this repo):
+```
+cd <repo_path>/model_hub
+make build
+pip install --find-links=./dist model-hub
+```
+
+## Preprocessing Datasets
+You first must preprocess your dataset before finetuning. To do this we will use the `prepare_lm_data.py` script.
+
+To be able to run the script via Determined it needs to be uploaded to the mounted PVC.
+
+### Script Usage
+```
+usage: prepare_lm_data.py [-h] --dataset_name DATASET_NAME --processed_dataset_destination PROCESSED_DATASET_DESTINATION --tokenizer_name TOKENIZER_NAME [--dataset_config_name DATASET_CONFIG_NAME]
+                          [--validation_split_percentage VALIDATION_SPLIT_PERCENTAGE] [--dataset_cache_dir DATASET_CACHE_DIR] [--tokenizer_cache_dir TOKENIZER_CACHE_DIR] [--tokenizer_revision TOKENIZER_REVISION]
+                          [--preprocessing_num_workers PREPROCESSING_NUM_WORKERS] [--preprocessing_batch_size PREPROCESSING_BATCH_SIZE] [--max_seq_len MAX_SEQ_LEN] [--overwrite_cache]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --dataset_name DATASET_NAME
+                        Path argument to pass to HuggingFace ``datasets.load_dataset``
+  --processed_dataset_destination PROCESSED_DATASET_DESTINATION
+                        Path to directory where the preprocessed dataset will be saved.
+  --tokenizer_name TOKENIZER_NAME
+                        Path to pretrained model or model identifier from huggingface.co/models
+  --dataset_config_name DATASET_CONFIG_NAME
+                        The name of the dataset configuration to pass to HuggingFace ``datasets.load_dataset``.
+  --validation_split_percentage VALIDATION_SPLIT_PERCENTAGE
+                        This is used to create a validation split from the training data when a dataset does not have a predefined validation split.
+  --dataset_cache_dir DATASET_CACHE_DIR
+                        Path to the directory to be used as a cache when downloading the dataset. A previously cached dataset will be used instead of redownloaded.
+  --tokenizer_cache_dir TOKENIZER_CACHE_DIR
+                        Path to the directory to be used as a cache when downloading the tokenizer. A previously cached tokenizer will be used instead of redownloaded.
+  --tokenizer_revision TOKENIZER_REVISION
+                        The specific model version to use (can be a branch name, tag name or commit id)
+  --preprocessing_num_workers PREPROCESSING_NUM_WORKERS
+                        Number of workers to use when tokenizing the dataset
+  --preprocessing_batch_size PREPROCESSING_BATCH_SIZE
+                        Batch size of texts when preprocessing. Defaults to 1000
+  --max_seq_len MAX_SEQ_LEN
+                        Max sequence length for each tokenized input. Defaults to 1024
+  --overwrite_cache     Flag to specify if the preprocessing cache should be overwritten.
+```
+
+### Example Call
+```
+det run 'python /mnt/finetune-opt/prepare_lm_data.py \ 
+    --dataset_name wikitext \
+    --dataset_config_name wikitext-103-raw-v1 \
+    --processed_dataset_destination /mnt/finetune-opt/wikitext/processed \
+    --tokenizer_name facebook/opt-125m \
+    --dataset_cache_dir /mnt/finetune-opt/wikitext'
+```
+
+## Running Experiments
+
+To run either of the included experiment configurations you must use the `det experiment create` command.
+```
+det experiment create opt125m_single.yml .
+det experiment create opt125m_search.yml .
+```

--- a/examples/deepspeed/huggingface/ds_config.json
+++ b/examples/deepspeed/huggingface/ds_config.json
@@ -1,0 +1,42 @@
+{
+    "train_micro_batch_size_per_gpu": 4,
+    "gradient_accumulation_steps": 32,
+    "optimizer": {
+        "type": "Adam",
+        "params": {
+            "lr": 0.001,
+            "betas": [
+                0.9,
+                0.95
+            ],
+            "eps": 1e-8
+        }
+    },
+    "scheduler": {
+        "type": "WarmupLR",
+        "params": {
+            "warmup_min_lr": 0,
+            "warmup_max_lr": 0.001,
+            "warmup_num_steps": 1000
+        }
+    },
+    "fp16": {
+        "enabled": true,
+        "loss_scale": 0.0,
+        "loss_scale_window": 1000,
+        "hysteresis": 2,
+        "min_loss_scale": 1,
+        "initial_scale_power": 15
+    },
+    "gradient_clipping": 1.0,
+    "prescale_gradients": false,
+    "zero_optimization": {
+        "stage": 1,
+        "allgather_partitions": true,
+        "allgather_bucket_size": 5e8,
+        "overlap_comm": true,
+        "reduce_scatter": true,
+        "reduce_bucket_size": 5e8,
+        "contiguous_gradients": true
+    }
+}

--- a/examples/deepspeed/huggingface/lm_trial.py
+++ b/examples/deepspeed/huggingface/lm_trial.py
@@ -1,0 +1,94 @@
+import logging
+from typing import Any, Dict, Iterator, Optional, Union
+
+import datasets
+import deepspeed
+import model_hub.huggingface as hf
+import torch
+from attrdict import AttrDict
+from determined.pytorch import DataLoader, TorchData
+from determined.pytorch.deepspeed import DeepSpeedTrial, DeepSpeedTrialContext, overwrite_deepspeed_config
+from transformers import default_data_collator
+
+
+class HFDeepSpeedTrial(DeepSpeedTrial):
+    def __init__(self, context: DeepSpeedTrialContext) -> None:
+        self.logger = logging.getLogger(__name__)
+        self.context = context
+        self.hparams = AttrDict(self.context.get_hparams())
+        self.data_config = AttrDict(self.context.get_data_config())
+        self.exp_config = AttrDict(self.context.get_experiment_config())
+
+        # Parse hparams and data_config.
+        (
+            self.config_kwargs,
+            self.tokenizer_kwargs,
+            self.model_kwargs,
+        ) = hf._config_parser.default_parse_config_tokenizer_model_kwargs(self.hparams)
+
+        (
+            self.config,
+            self.tokenizer,
+            self.model
+        ) = hf.build_using_auto(self.config_kwargs,
+                                self.tokenizer_kwargs,
+                                self.hparams.model_mode,
+                                self.model_kwargs,
+                                use_pretrained_weights=self.hparams.use_pretrained_weights)
+
+        self.tokenized_datasets = datasets.load_from_disk(self.data_config.preprocessed_dataset_path)
+        for _, data in self.tokenized_datasets.items():
+            hf.remove_unused_columns(self.model, data)
+
+        self.model.resize_token_embeddings(len(self.tokenizer))
+
+        # Overwrite values in the deepspeed config json with values from the Determined context
+        overwrite_deepspeed_args = self.hparams.get("overwrite_deepspeed_args", {})
+
+        # Make sure the optimizer LR and max LR for the WarmupLR scheduler are the same
+        try:
+            optimizer_lr = overwrite_deepspeed_args["optimizer"]["params"]["lr"]
+            overwrite_deepspeed_args["scheduler"] = {"params": {"warmup_max_lr": optimizer_lr}}
+        except KeyError:
+            # There was no Optimizer LR hyperparameter
+            pass
+
+        self.ds_config = overwrite_deepspeed_config(self.hparams.deepspeed_config_file,
+                                                    overwrite_deepspeed_args)
+
+        parameters = filter(lambda p: p.requires_grad, self.model.parameters())
+        model_engine, _, _, _ = deepspeed.initialize(model=self.model,
+                                                     model_parameters=parameters,
+                                                     config=self.ds_config)
+        self.model_engine = self.context.wrap_model_engine(model_engine)
+
+    def build_training_data_loader(self) -> DataLoader:
+        return DataLoader(
+            self.tokenized_datasets["train"],
+            batch_size=self.ds_config["train_micro_batch_size_per_gpu"],
+            collate_fn=default_data_collator,
+        )
+
+    def build_validation_data_loader(self) -> DataLoader:
+        return DataLoader(self.tokenized_datasets["validation"],
+                          batch_size=self.ds_config["train_micro_batch_size_per_gpu"],
+                          collate_fn=default_data_collator)
+
+    def train_batch(self,
+                    dataloader_iter: Optional[Iterator[TorchData]],
+                    epoch_idx: int,
+                    batch_idx: int) -> Union[torch.Tensor, Dict[str, Any]]:
+        inputs = self.context.to_device(next(dataloader_iter))
+        outputs = self.model_engine(**inputs)
+        loss = outputs["loss"] if isinstance(outputs, dict) else outputs[0]
+        self.model_engine.backward(loss)
+        self.model_engine.step()
+        return {"loss": loss}
+
+    def evaluate_batch(self,
+                       dataloader_iter: Optional[Iterator[TorchData]],
+                       batch_idx: int) -> Dict[str, Any]:
+        inputs = self.context.to_device(next(dataloader_iter))
+        outputs = self.model_engine(**inputs)
+        loss = outputs["loss"] if isinstance(outputs, dict) else outputs[0]
+        return {"loss": loss}

--- a/examples/deepspeed/huggingface/opt125m_search.yml
+++ b/examples/deepspeed/huggingface/opt125m_search.yml
@@ -1,0 +1,43 @@
+name: huggingface_deepspeed_opt125m_search
+hyperparameters:
+  pretrained_model_name_or_path: facebook/opt-125m
+  cache_dir: /mnt/finetune-opt-125m/opt-125m
+  use_pretrained_weights: true
+  model_mode: causal-lm
+  deepspeed_config_file: "ds_config.json"
+  overwrite_deepspeed_args:
+    train_micro_batch_size_per_gpu:
+      type: categorical
+      vals:
+        - 2
+        - 4
+        - 8
+        - 16
+records_per_epoch: 116017
+data:
+  preprocessed_dataset_path: /mnt/finetune-opt-125m/wikitext/processed
+searcher:
+  name: grid
+  metric: loss
+  smaller_is_better: true
+  max_concurrent_trials: 2  # Max of 16 GPUs at once (max_concurrent_trials * slots_per_trial)
+  max_length:
+    epochs: 3
+perform_initial_validation: true
+min_validation_period:
+  epochs: 1
+min_checkpoint_period:
+  epochs: 1
+environment:
+  image:
+    gpu: navarrepratt/hf_deepspeed_det:1
+resources:
+  slots_per_trial: 8
+profiling:
+  enabled: true
+entrypoint:
+  - python3
+  - -m
+  - determined.launch.deepspeed
+  - --trial
+  - lm_trial:HFDeepSpeedTrial

--- a/examples/deepspeed/huggingface/opt125m_single.yml
+++ b/examples/deepspeed/huggingface/opt125m_single.yml
@@ -1,0 +1,36 @@
+name: huggingface_deepspeed_opt125m_single
+hyperparameters:
+  pretrained_model_name_or_path: facebook/opt-125m
+  cache_dir: /mnt/finetune-opt-125m/opt-125m
+  use_pretrained_weights: true
+  model_mode: causal-lm
+  deepspeed_config_file: "ds_config.json"
+  overwrite_deepspeed_args:
+    train_micro_batch_size_per_gpu: 16
+records_per_epoch: 116017  # This is from `len(preprocessed_dataset["train"])`
+data:
+  preprocessed_dataset_path: /mnt/finetune-opt-125m/wikitext/processed
+searcher:
+  name: single
+  metric: loss
+  smaller_is_better: true
+  max_length:
+    epochs: 10
+perform_initial_validation: true
+min_validation_period:
+  epochs: 1
+min_checkpoint_period:
+  epochs: 1
+environment:
+  image:
+    gpu: navarrepratt/hf_deepspeed_det:1
+resources:
+  slots_per_trial: 8
+profiling:
+  enabled: true
+entrypoint:
+  - python3
+  - -m
+  - determined.launch.deepspeed
+  - --trial
+  - lm_trial:HFDeepSpeedTrial

--- a/examples/deepspeed/huggingface/prepare_lm_data.py
+++ b/examples/deepspeed/huggingface/prepare_lm_data.py
@@ -1,0 +1,173 @@
+import argparse
+import logging
+from pathlib import Path
+from typing import Union
+from functools import partial
+
+import transformers
+from datasets import load_dataset, Dataset, DatasetDict, IterableDatasetDict
+
+logger = logging.getLogger("prepare_data")
+
+
+def get_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+
+    # Required args
+    parser.add_argument("--dataset_name",
+                        type=str,
+                        required=True,
+                        help="Path argument to pass to HuggingFace ``datasets.load_dataset``")
+    parser.add_argument("--processed_dataset_destination",
+                        type=str,
+                        required=True,
+                        help="Path to directory where the preprocessed dataset will be saved.")
+    parser.add_argument("--tokenizer_name",
+                        type=str,
+                        required=True,
+                        help="Path to pretrained model or model identifier from huggingface.co/models")
+
+    # Optional Dataset args
+    parser.add_argument("--dataset_config_name",
+                        type=str,
+                        default=None,
+                        help="The name of the dataset configuration to pass to HuggingFace ``datasets.load_dataset``.")
+    parser.add_argument("--validation_split_percentage",
+                        type=float,
+                        default=None,
+                        help="This is used to create a validation split from the training data when a dataset does " +
+                             "not have a predefined validation split.")
+    parser.add_argument("--dataset_cache_dir",
+                        type=Path,
+                        default=None,
+                        help="Path to the directory to be used as a cache when downloading the dataset. " +
+                             "A previously cached dataset will be used instead of redownloaded.")
+
+    # Optional tokenizer args
+    parser.add_argument("--tokenizer_cache_dir",
+                        type=Path,
+                        default=None,
+                        help="Path to the directory to be used as a cache when downloading the tokenizer. " +
+                             "A previously cached tokenizer will be used instead of redownloaded.")
+    parser.add_argument("--tokenizer_revision",
+                        type=str,
+                        default="main",
+                        help="The specific model version to use (can be a branch name, tag name or commit id)")
+
+    # Optional preprocessing args
+    parser.add_argument("--preprocessing_num_workers",
+                        type=int,
+                        default=1,
+                        help="Number of workers to use when tokenizing the dataset")
+    parser.add_argument("--preprocessing_batch_size",
+                        type=int,
+                        default=1000,
+                        help="Batch size of texts when preprocessing. Defaults to 1000")
+    parser.add_argument("--max_seq_len",
+                        type=int,
+                        default=1024,
+                        help="Max sequence length for each tokenized input. Defaults to 1024")
+    parser.add_argument("--overwrite_cache",
+                        action="store_true",
+                        help="Flag to specify if the preprocessing cache should be overwritten.")
+
+    return parser.parse_args()
+
+
+def load_raw_dataset(dataset_name: str,
+                     dataset_config_name: str,
+                     dataset_cache_dir: str,
+                     validation_split_percentage: float) -> Union[DatasetDict, IterableDatasetDict]:
+    datasets = load_dataset(dataset_name,
+                            dataset_config_name,
+                            cache_dir=dataset_cache_dir)
+
+    assert hasattr(datasets, "keys"), "Expected a dictionary of datasets."
+
+    if "validation" not in datasets.keys():
+        assert validation_split_percentage is not None, \
+            "Validation split not provided by this huggingface dataset. " \
+            "Please specify validation_split_percentage in data_config for use to create validation set."
+
+        datasets["validation"] = load_dataset(dataset_name,
+                                              dataset_config_name,
+                                              split=f"train[:{validation_split_percentage}%]")
+        datasets["train"] = load_dataset(dataset_name,
+                                         dataset_config_name,
+                                         split=f"train[{validation_split_percentage}%:]")
+
+    return datasets
+
+
+def build_datasets(raw_ds: Union[DatasetDict, IterableDatasetDict],
+                   tokenizer: transformers.PreTrainedTokenizer,
+                   preprocessing_num_workers: int,
+                   preprocessing_batch_size: int,
+                   max_seq_len: int,
+                   overwrite_cache: bool) -> Union[Dataset, DatasetDict]:
+    column_names = raw_ds["train"].column_names
+    text_column_name = "text" if "text" in column_names else column_names[0]
+
+    def tokenize_func(tokenizer, examples):
+        return tokenizer(examples[text_column_name])
+
+    tokenized_datasets = raw_ds.map(partial(tokenize_func, tokenizer),
+                                    batched=True,
+                                    num_proc=preprocessing_num_workers,
+                                    remove_columns=column_names,
+                                    load_from_cache_file=not overwrite_cache)
+
+    if tokenizer.model_max_length < max_seq_len:
+        logger.warning("The max_seq_len passed is larger than the maximum length for the model. Using max_seq_len="
+                       f"{tokenizer.model_max_length}.")
+        max_seq_len = tokenizer.model_max_length
+
+    # Main data processing function that will concatenate all texts from our dataset and generate chunks of max_seq_len
+    def group_texts(examples):
+        # Concatenate all texts.
+        concatenated_examples = {k: sum(examples[k], []) for k in examples.keys()}
+        total_length = len(concatenated_examples[list(examples.keys())[0]])
+        # We drop the small remainder. We could add padding if the model supported it instead of this drop.
+        # You can customize this part to your needs
+        total_length = (total_length // max_seq_len) * max_seq_len
+        # Split chunks of max_len
+        result = {key: [text[i: i+max_seq_len] for i in range(0, total_length, max_seq_len)]
+                  for key, text in concatenated_examples.items()}
+        result["labels"] = result["input_ids"].copy()
+        return result
+
+    # Note that with `batched=True`, this map processes 1,000 texts together,
+    # so group_texts throws away a remainder for each of these groups of 1,000 texts.
+    # You can adjust that batch_size here but a higher value might be slower to preprocess.
+    lm_datasets = tokenized_datasets.map(group_texts,
+                                         batched=True,
+                                         batch_size=preprocessing_batch_size,
+                                         num_proc=preprocessing_num_workers,
+                                         load_from_cache_file=not overwrite_cache)
+
+    return lm_datasets
+
+
+def main() -> None:
+    args = get_args()
+
+    tokenizer = transformers.AutoTokenizer.from_pretrained(pretrained_model_name_or_path=args.tokenizer_name,
+                                                           cache_dir=args.tokenizer_cache_dir,
+                                                           revision=args.tokenizer_revision,
+                                                           use_fast=True)
+    raw_ds = load_raw_dataset(args.dataset_name,
+                              args.dataset_config_name,
+                              args.dataset_cache_dir,
+                              args.validation_split_percentage)
+    lm_datasets = build_datasets(raw_ds,
+                                 tokenizer,
+                                 args.preprocessing_num_workers,
+                                 args.preprocessing_batch_size,
+                                 args.max_seq_len,
+                                 args.overwrite_cache)
+
+    lm_datasets.save_to_disk(args.processed_dataset_destination)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/deepspeed/huggingface/requirements.txt
+++ b/examples/deepspeed/huggingface/requirements.txt
@@ -1,0 +1,6 @@
+transformers==4.25.1
+datasets==2.7.1
+determined==0.19.8
+--find-links https://download.pytorch.org/whl/cu113/torch_stable.html
+torch==1.10.2+cu113
+attrdict==2.0.1


### PR DESCRIPTION
This PR adds another `DeepSpeedTrial` example but instead of using a model repo like gpt-neox or defining the pytorch model locally it uses a Hugging Face model, specifically OPT-125m. It also uses the Wikitext dataset from hugging face to perform fine tuning.