### PR TITLE
fix (k8s): enableServiceLinks: false

### DIFF
--- a/helm/charts/determined/Chart.yaml
+++ b/helm/charts/determined/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: determined
 description: An open source deep learning training platform with support for distributed training and hyperparameter search.
-version: "0.18.54"
+version: "0.18.56"
 icon: https://github.com/determined-ai/determined/blob/master/determined-logo.png?raw=true
 home: https://www.determined.ai/
 annotations:

--- a/helm/charts/determined/templates/_helpers.tpl
+++ b/helm/charts/determined/templates/_helpers.tpl
@@ -9,6 +9,7 @@
 {{- define "determined.cpuPodSpec" -}}
 spec:
   priorityClassName: determined-system-priority
+  enableServiceLinks: false
   containers:
   - name: determined-container
     resources:
@@ -23,6 +24,7 @@ spec:
 {{- define "determined.gpuPodSpec" -}}
 spec:
   priorityClassName: determined-system-priority
+  enableServiceLinks: false
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/helm/charts/determined/templates/master-deployment.yaml
+++ b/helm/charts/determined/templates/master-deployment.yaml
@@ -22,6 +22,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/master-config.yaml") . | sha256sum }}
     spec:
       serviceAccount: determined-master-{{ .Release.Name }}
+      enableServiceLinks: false
       containers:
       - name: determined-master-{{ .Release.Name }}
         {{ $image := "determined-master" }}


### PR DESCRIPTION
This PR disables service links by default so that additional environment information about services running in k8s is not injected into the pod
