### PR TITLE
feat(update): Upgrading to 0.23.2 without /dev/shm in pod_spec

### DIFF
--- a/helm/charts/determined/Chart.yaml
+++ b/helm/charts/determined/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: determined
 description: An open source deep learning training platform with support for distributed training and hyperparameter search.
-version: "0.18.77"
+version: "0.18.81"
 icon: https://github.com/determined-ai/determined/blob/master/determined-logo.png?raw=true
 home: https://www.determined.ai/
 annotations:
@@ -11,4 +11,4 @@ annotations:
 # a non-release version (e.g., X.Y.Z.dev0) you will have to specify an
 # existing official release version (e.g., X.Y.Z) or specify a commit has
 # that has been publicly published (all commits from master).
-appVersion: "0.19.9"
+appVersion: "0.23.2"

--- a/helm/charts/determined/templates/_helpers.tpl
+++ b/helm/charts/determined/templates/_helpers.tpl
@@ -29,16 +29,11 @@ spec:
         memory: 64Gi
         cpu: 32
     volumeMounts:
-      - mountPath: /dev/shm
-        name: dshm
       {{- range .Values.mounts }}
       - name: {{ regexReplaceAll "[_]" .pvc "-" | lower }}
         mountPath: {{ .name }}
       {{- end }}
   volumes:
-    - name: dshm
-      emptyDir:
-        medium: Memory
     {{- range .Values.mounts }}
     - name: {{ regexReplaceAll "[_]" .pvc "-" | lower }}
       persistentVolumeClaim:
@@ -76,16 +71,11 @@ spec:
         rdma/ib: '1'
       {{- end }}
     volumeMounts:
-      - mountPath: /dev/shm
-        name: dshm
       {{- range .Values.mounts }}
       - name: {{ regexReplaceAll "[_]" .pvc "-" | lower }}
         mountPath: {{ .name }}
       {{- end }}
   volumes:
-    - name: dshm
-      emptyDir:
-        medium: Memory
     {{- range .Values.mounts }}
     - name: {{ regexReplaceAll "[_]" .pvc "-" | lower }}
       persistentVolumeClaim:


### PR DESCRIPTION
This PR removes /dev/shm from the default pod spec to not conflict with the ModRule causing duplicate injection. It also bumps the Chart Version to 0.23.2