### PR TITLE
feat(upgrade): Determined.ai v0.28.1

### DIFF
--- a/helm/charts/determined/Chart.yaml
+++ b/helm/charts/determined/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: determined
 description: An open source deep learning training platform with support for distributed training and hyperparameter search.
-version: "0.18.87"
+version: "0.18.88"
 icon: https://raw.githubusercontent.com/determined-ai/determined/0.26.6/determined-logo.png
 home: https://www.determined.ai/
 annotations:
@@ -11,4 +11,4 @@ annotations:
 # a non-release version (e.g., X.Y.Z.dev0) you will have to specify an
 # existing official release version (e.g., X.Y.Z) or specify a commit has
 # that has been publicly published (all commits from master).
-appVersion: "0.28.0"
+appVersion: "0.28.1"


### PR DESCRIPTION
Version 0.28.1

**Improvements**

The Google Cloud Storage client will now retry following the default policy on TooManyRequests rate limit errors.

**Bug Fixes**

Since 0.26.2, it was possible to cause Determined trials and commands to hang after the main process exited but before the container exited, by starting a non-terminating subprocess from your training script or command that kept an open stdout or stderr file descriptor. Now, logs from subprocesses of your main process are ignored after your main process has exited.
TensorBoard: Fix a bug that would allow users to view TensorBoards even if they did not have permission to view the corresponding workspaces.
